### PR TITLE
fix: update ACCELA Linux asset filename to -linux.tar.gz

### DIFF
--- a/accela
+++ b/accela
@@ -203,7 +203,7 @@ fetch_api_data() {
     RELEASE_JSON="{
       \"tag_name\": \"$LATEST_TAG\",
       \"assets\": [
-        {\"browser_download_url\": \"$BASE/ACCELA-${LATEST_TAG}-linux-appimage.tar.gz\"},
+        {\"browser_download_url\": \"$BASE/ACCELA-${LATEST_TAG}-linux.tar.gz\"},
         {\"browser_download_url\": \"$BASE/ACCELA-${LATEST_TAG}-linux-source.tar.gz\"}
       ]
     }"


### PR DESCRIPTION
O arquivo em Reloase foi renomeado de "-linux-appimage.tar.gz" para -linux.tar.gz, mas o script ainda usava o nome antigo, fazendo com que a busca pela URL de download falhasse.
