### PR TITLE
feat(fix-deps): add opensuse/zypper support

### DIFF
--- a/fix-deps
+++ b/fix-deps
@@ -58,6 +58,12 @@ detect_distro_family() {
         return 0
     fi
 
+    # OpenSUSE
+    if [[ "$ID" =~ opensuse || "$ID_LIKE" =~ opensuse ]]; then
+        echo "opensuse"
+        return 0
+    fi
+
     # Void Linux
    if [[ "$ID" == "void" ]]; then
         echo "void"
@@ -102,6 +108,14 @@ install_packages() {
                 ;;
             arch)
                 if sudo pacman -Sy --noconfirm "$pkg" 2>/dev/null; then
+                    echo -e "  ${GREEN}✓${NC} $pkg"
+                else
+                    echo -e "  ${YELLOW}⊘${NC} $pkg (not found)"
+                    skipped=$((skipped + 1))
+                fi
+                ;;
+            opensuse)
+                if sudo zypper install -y "$pkg" 2>/dev/null; then
                     echo -e "  ${GREEN}✓${NC} $pkg"
                 else
                     echo -e "  ${YELLOW}⊘${NC} $pkg (not found)"
@@ -184,6 +198,9 @@ install_dependencies() {
         arch)
             install_packages "p7zip" "$FAMILY"
             ;;
+        opensuse)
+            install_packages "p7zip-full p7zip" "$FAMILY"
+            ;;
         void)
             install_packages "p7zip 7zip" "$FAMILY"
             ;;
@@ -204,6 +221,10 @@ install_dependencies() {
             ;;
         arch)
             ACCELA_PACKAGES="python xcb-util-cursor libnotify git"
+            install_packages "$ACCELA_PACKAGES" "$FAMILY"
+            ;;
+        opensuse)
+            ACCELA_PACKAGES="python3 libxcb-cursor0 libnotify-tools git libgthread-2_0-0"
             install_packages "$ACCELA_PACKAGES" "$FAMILY"
             ;;
         void)
@@ -227,6 +248,10 @@ install_dependencies() {
             ;;
         arch)
             SLS_PACKAGES="lib32-glibc lib32-openssl lib32-curl curl"
+            install_packages "$SLS_PACKAGES" "$FAMILY"
+            ;;
+        opensuse)
+            SLS_PACKAGES="glibc-32bit libcurl4-32bit libopenssl3-32bit"
             install_packages "$SLS_PACKAGES" "$FAMILY"
             ;;
         void)


### PR DESCRIPTION
This PR adds OpenSUSE support to the `fix-deps` script. 

### What
- Introduces OS detection for the OpenSUSE family (via `ID` and `ID_LIKE` in `/etc/os-release`).
- Implements `zypper` as the package manager in the `install_packages` function.
- Maps the required dependencies to their exact OpenSUSE package names, including the `-32bit` equivalents needed for SLSsteam (e.g., `glibc-32bit`, `libcurl4-32bit`, `libopenssl3-32bit`).

### Why
Users running OpenSUSE were experiencing immediate installation failures when running the combo installer because `fix-deps` did not recognize the distribution family and exited with an error. This patch extends compatibility to OpenSUSE natively without breaking existing distributions.

### Testing
Tested successfully on a fresh OpenSUSE system. All dependencies (both 64-bit and 32-bit) install cleanly and correctly.