### PR TITLE
fix(fix-deps): prevent catastrophic t64 conflict on modern Ubuntu/Debian

### DIFF
--- a/fix-deps
+++ b/fix-deps
@@ -222,7 +222,11 @@ install_dependencies() {
             install_packages "$SLS_PACKAGES" "$FAMILY"
             ;;
         debian)
-            SLS_PACKAGES="libc6:i386 libcurl4-openssl-dev libcurl4 libcurl4:i386 libssl3:i386 libcrypto++9:i386"
+            if apt-cache search "^libcurl4t64$" 2>/dev/null | grep -q "libcurl4t64"; then
+                SLS_PACKAGES="libc6:i386 libcurl4-openssl-dev libcurl4t64 libcurl4t64:i386 libssl3t64:i386 libcrypto++9:i386"
+            else
+                SLS_PACKAGES="libc6:i386 libcurl4-openssl-dev libcurl4 libcurl4:i386 libssl3:i386 libcrypto++9:i386"
+            fi
             install_packages "$SLS_PACKAGES" "$FAMILY"
             ;;
         arch)


### PR DESCRIPTION
### What
This PR adds dynamic `time_t` (t64) detection for Debian-based distributions to prevent a critical bug where `apt` automatically uninstalls the user's entire desktop environment.

### Why
On modern Ubuntu (24.04+) and Debian Trixie/13, the Time_t 64-bit transition replaced `libcurl4` with `libcurl4t64`.
Because `fix-deps` hardcodes `libcurl4` and passes `sudo apt-get install -y`, `apt` resolves the conflict by automatically uninstalling `libcurl4t64`. Since `libcurl4t64` is a core dependency for `flatpak`, `curl`, `gnome-shell`, and many desktop environments, the user's entire OS graphical interface gets destroyed in the process.

Additionally, SLSsteam requires the 32-bit curl library to function, which is now named `libcurl4t64:i386`. The old `libcurl4:i386` fails to install on these newer systems.

### How
By using `apt-cache search ^libcurl4t64$`, the script now elegantly checks if the system uses the new `t64` naming scheme. If it does, it requests `libcurl4t64` and `libcurl4t64:i386`, ensuring total compatibility and preventing any destructive package removals.