### PR TITLE
Fix: add missing shared libraries for NixOS

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -38,9 +38,9 @@ pkgs.stdenv.mkDerivation rec {
     install -Dm755 "$unpack_dir/bin/ACCELA.AppImage" "$out/share/accela/ACCELA.AppImage"
     install -Dm644 "$unpack_dir/bin/accela.png" "$out/share/pixmaps/accela.png"
 
-    # Override appimage-run to add missing libraries (like zstd)
+    # Override appimage-run to add missing libraries
     appimageRun="${pkgs.appimage-run.override {
-      extraPkgs = pkgs: [ pkgs.zstd ];
+      extraPkgs = pkgs: [ pkgs.xcb-util-cursor pkgs.zstd pkgs.icu ];
     }}"
 
     makeWrapper "$appimageRun/bin/appimage-run" "$out/bin/accela" \


### PR DESCRIPTION
## Summary

Fixes #46

Adds `xcb-util-cursor` and `icu` to the `appimage-run` `extraPkgs` to resolve issues on NixOS.

- `xcb-util-cursor`: required by Qt xcb platform plugin (without it, ACCELA fails to start)
- `icu`: required by dotnet-runtime for Steamless DRM removal (without it, ACCELA starts fine but Steamless fails with "Could not find a valid ICU package installed on the system")

## Testing

Tested on NixOS 25.05, Cinnamon, X11. Observed errors:
- Without `xcb-util-cursor`: "Could not load the Qt platform plugin \"xcb\""
- Without `zstd`: "ImportError: libzstd.so.1: cannot open shared object file"
- Without `icu`: ACCELA runs, but Steamless DRM removal fails

## Environment

- NixOS 25.05
- Cinnamon on X11
- ACCELA 20260512201930
- Working config: [c4i0b/nixos-config@9ecd64d](https://github.com/c4i0b/nixos-config/blob/9ecd64d/overlays/default.nix#L22-L24)