### PR TITLE
use appimageTools for NixOS derivation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,57 +1,41 @@
-{ pkgs ? import <nixpkgs> { config.allowUnfree = true; } }:
-
+{
+  lib,
+  appimageTools,
+  fetchurl,
+}:
 let
+  pname = "accela";
   version = "20260524150213";
 
-  desktopItem = pkgs.makeDesktopItem {
-    name = "accela";
-    exec = "accela";
-    icon = "accela";
-    comment = "ACCELA - Steam Library Manager";
-    desktopName = "ACCELA";
-    categories = [ "Game" "Utility" ];
-    terminal = false;
-  };
-in
-pkgs.stdenv.mkDerivation rec {
-  pname = "accela";
-  inherit version;
-
-  src = pkgs.fetchurl {
+  src = fetchurl {
     url = "https://github.com/ciscosweater/enter-the-wired/releases/download/${version}/ACCELA-${version}-linux.tar.gz";
-    hash = "sha256-G6lHo8TQYMkGSVGVhHHiFm3JlwrO8iliKWvFOUI+UcY=";
+    hash = "sha256-Zu7ES0ecHIiUEcHZJZ+fBNqXIlz9BCBtWgmvBhd6eSY=";
+    downloadToTemp = true;
+    postFetch = ''
+      tar -xf "file" "bin/ACCELA.AppImage"
+      install -m 444 "bin/ACCELA.AppImage" "$out"
+    '';
   };
 
-  nativeBuildInputs = [ pkgs.copyDesktopItems pkgs.makeWrapper ];
+  appimageContents = appimageTools.extract { inherit pname version src; };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+  extraPkgs =
+    pkgs: with pkgs; [
+      icu
+      xcb-util-cursor
+      zstd
+    ];
 
-  desktopItems = [ desktopItem ];
-
-  dontUnpack = true;
-
-  installPhase = ''
-    runHook preInstall
-
-    unpack_dir="$TMPDIR/accela"
-    mkdir -p "$unpack_dir" "$out/bin" "$out/share/accela" "$out/share/pixmaps"
-    tar -xzf "$src" -C "$unpack_dir"
-
-    install -Dm755 "$unpack_dir/bin/ACCELA.AppImage" "$out/share/accela/ACCELA.AppImage"
-    install -Dm644 "$unpack_dir/bin/accela.png" "$out/share/pixmaps/accela.png"
-
-    # Override appimage-run to add missing libraries
-    appimageRun="${pkgs.appimage-run.override {
-      extraPkgs = pkgs: [ pkgs.xcb-util-cursor pkgs.zstd pkgs.icu ];
-    }}"
-
-    makeWrapper "$appimageRun/bin/appimage-run" "$out/bin/accela" \
-      --add-flags "$out/share/accela/ACCELA.AppImage"
-
-    copyDesktopItems
-
-    runHook postInstall
+  extraInstallCommands = ''
+    install -m 444 -D "${appimageContents}/accela.png" "$out/share/pixmaps/accela.png"
+    install -m 444 -D "${appimageContents}/ACCELA.desktop" "$out/share/applications/accela.desktop"
+    substituteInPlace $out/share/applications/accela.desktop \
+      --replace-fail 'Exec=run.sh' 'Exec=accela'
   '';
 
-  meta = with pkgs.lib; {
+  meta = with lib; {
     description = "ACCELA AppImage package for Enter The Wired";
     license = licenses.mit;
     platforms = platforms.linux;

--- a/flake.nix
+++ b/flake.nix
@@ -6,27 +6,38 @@
     nixpkgs.url = "github:NixOS/nixpkgs/9dcb002ca1690658be4a04645215baea8b95f31d";
   };
 
-  outputs = { self, nixpkgs }:
+  outputs =
+    { self, nixpkgs }:
     let
       supportedSystems = [ "x86_64-linux" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
-      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; config.allowUnfree = true; });
+      nixpkgsFor = forAllSystems (
+        system:
+        import nixpkgs {
+          inherit system;
+          config.allowUnfree = true;
+        }
+      );
     in
     {
-      packages = forAllSystems (system:
+      packages = forAllSystems (
+        system:
         let
           pkgs = nixpkgsFor.${system};
         in
         {
-          default = import ./default.nix { inherit pkgs; };
-        });
+          default = pkgs.callPackage ./default.nix { };
+        }
+      );
 
-      devShells = forAllSystems (system:
+      devShells = forAllSystems (
+        system:
         let
           pkgs = nixpkgsFor.${system};
         in
         {
           default = import ./shell.nix { inherit pkgs; };
-        });
+        }
+      );
     };
 }


### PR DESCRIPTION
Hi! 

I've refactored the Nix expression to use the standard nixpkgs `appimageTools` helper instead of a manual `mkDerivation` with `appimage-run`. 

### What changed and why:
* **Switched to `appimageTools`:** The current setup wraps the AppImage using `appimage-run` at runtime. While this works, `appimage-run` has to unpack the AppImage contents into the user's `~/.cache` directory on run. This adds startup overhead and pollutes the user's home folder. Using `wrapType2` is the idiomatic Nix way to handle AppImages; it avoids the runtime extraction to `~/.cache`.
* **Reused assets:** Instead of hardcoding a custom desktop item in the Nix expression, the new version extracts the original `.desktop` and `.png` icon directly from the AppImage contents and patches the `Exec` line. This ensures the desktop entry stays in sync with any upstream updates.
* **Switched from direct `import` to `callPackage`:** In `flake.nix`, I updated the code to import the package using `pkgs.callPackage` instead of a direct `import`. This allows Nix to automatically inject required dependencies (like `lib`, `appimageTools`, and `fetchurl`) instead of having to pass the entire `pkgs` set manually.
* **Formatted with `nixfmt`:** I ran `nixfmt` on `flake.nix` and the package file to align the codebase with standard Nix formatting guidelines.

Let me know what you think! I'm open to any feedback or changes if needed.