### PR TITLE
Fix: match release asset filename to fix NixOS build (404)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ let
   version = "20260524150213";
 
   src = fetchurl {
-    url = "https://github.com/ciscosweater/enter-the-wired/releases/download/${version}/ACCELA-${version}-linux.tar.gz";
+    url = "https://github.com/ciscosweater/enter-the-wired/releases/download/latest/deps.tar.gz";
     hash = "sha256-Zu7ES0ecHIiUEcHZJZ+fBNqXIlz9BCBtWgmvBhd6eSY=";
     downloadToTemp = true;
     postFetch = ''


### PR DESCRIPTION
## Summary

Fixes #49

Updates the `fetchurl` in `default.nix` to point to the correct published release asset (`deps.tar.gz` on the `latest` tag) instead of the non-existent `ACCELA-${version}-linux.tar.gz`.

The `version` variable is still used by `appimageTools` for package naming — only the fetch URL was incorrect.

## Testing

Tested on NixOS 26.05, KDE on Wayland. ACCELA launches and operates correctly.

## Environment

- NixOS 26.05
- KDE on Wayland
- ACCELA 20260524150213
- Working config: [c4i0b/nixos-config@5b7d619 overlays/default.nix#L9](https://github.com/c4i0b/nixos-config/blob/5b7d619/overlays/default.nix#L9)